### PR TITLE
fix(config): Change pylsp to pyls

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -18,7 +18,7 @@ local supported_languages = {
   jsonls = { image = "lspcontainers/json-language-server:1.3.4", cmd = default_cmd },
   gopls = { image = "lspcontainers/gopls:0.6.11", cmd = default_cmd },
   html = { image = "lspcontainers/html-language-server:1.4.0", cmd = default_cmd },
-  pylsp = { image = "lspcontainers/python-lsp:1.0.1", cmd = default_cmd },
+  pyls = { image = "lspcontainers/python-lsp:1.0.1", cmd = default_cmd },
   pyright = { image = "lspcontainers/pyright-langserver:1.1.137", cmd = default_cmd },
   rust_analyzer = { image = "lspcontainers/rust-analyzer:2021-05-03", cmd = default_cmd },
   svelte = { image = "lspcontainers/svelte-language-server:0.13.7", cmd = default_cmd },


### PR DESCRIPTION
* I've aligned the README with the specifications.
  * An alias of python LSP is [`pyls`](https://github.com/palantir/python-language-server)