### PR TITLE
fix(config): change docker image for `dockerls`

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -14,7 +14,7 @@ end
 
 local supported_languages = {
   bashls = { image = "lspcontainers/bash-language-server:1.17.0", cmd = default_cmd },
-  dockerls = { image = "lspcontainers/docker-langserver:0.4.1", cmd = default_cmd },
+  dockerls = { image = "lspcontainers/docker-language-server:0.4.1", cmd = default_cmd },
   jsonls = { image = "lspcontainers/json-language-server:1.3.4", cmd = default_cmd },
   gopls = { image = "lspcontainers/gopls:0.6.11", cmd = default_cmd },
   html = { image = "lspcontainers/html-language-server:1.4.0", cmd = default_cmd },


### PR DESCRIPTION
* [`lspcontainers/docker-language-server:0.4.1`](https://hub.docker.com/layers/lspcontainers/docker-language-server/0.4.1/images/sha256-47f2718ab6a533400ee300375a232b6a3d56f1b5c8d6b1e414c98cffbab55d26?context=explore) is used as dockerls instead of `lspcontainers/docker-langserver:0.4.1`.
  * `lspcontainers/docker-langserver:0.4.1` does not exist.