### PR TITLE
feature: add intelephense

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Below is a list of supported language servers for configuration with `nvim-lspco
 - [tsserver](#tsserver)
 - [yamlls](#yamlls)
 - [vuels](#vuels)
+- [intelephense](#intelephense)
 
 ### bashls
 
@@ -265,6 +266,21 @@ require'lspconfig'.vuels.setup {
   end,
   cmd = require'lspcontainers'.command('vuels'),
   root_dir = util.root_pattern(".git", vim.fn.getcwd()),
+  ...
+}
+```
+
+### intelephense
+
+https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#intelephense
+
+```lua
+require'lspconfig'.intelephense.setup {
+  before_init = function(params)
+    params.processId = vim.NIL
+  end,
+  cmd = require'lspcontainers'.command('intelephense'),
+  root_dir = util.root_pattern("composer.json", ".git", vim.fn.getcwd()),
   ...
 }
 ```

--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -26,7 +26,8 @@ local supported_languages = {
   sumneko_lua = { image = "lspcontainers/lua-language-server:1.20.5", cmd = default_cmd },
   tsserver = { image = "lspcontainers/typescript-language-server:0.5.1", cmd = default_cmd },
   yamlls = { image = "lspcontainers/yaml-language-server:0.18.0", cmd = default_cmd },
-  vuels = { image = "lspcontainers/vue-language-server:0.7.2", cmd = default_cmd }
+  vuels = { image = "lspcontainers/vue-language-server:0.7.2", cmd = default_cmd },
+  intelephense = { image = "lspcontainers/intelephense:1.7.1", cmd = default_cmd }
 }
 
 local function command(server, user_opts)


### PR DESCRIPTION
This MR adds the [intelephense php language server](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#intelephense) configuration and docs.
See the dockerfile PR: https://github.com/lspcontainers/dockerfiles/pull/39

I have tested it with my lspcontainers.nvim fork locally.