### PR TITLE
Mount volumes as readonly

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -35,7 +35,7 @@ local function command(server, user_opts)
   local opts = user_opts or {}
 
   local workdir = opts.root_dir or vim.fn.getcwd()
-  local volume = workdir..":"..workdir
+  local volume = workdir..":"..workdir..":ro"
 
   local additional_languages = opts.additional_languages or {}
   local image = nil


### PR DESCRIPTION
LSPs don't need to directly alter files -- they only send changes and updates to neovim, which updates the buffer itself.

This makes volumes get mounted as read-only, following the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege). This means that if there's some bug in an LSP, they cannot cause any damage to the filesystem, even withing the current workspace.