### PR TITLE
Allow configuring containers with no network

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ lspconfig.gopls.setup {
 }
 ```
 
+### Network support
+
+By default, LSPs that don't require network access run with `network=none`.
+This means the container has not network access. If you have a special case
+where an LSP needs network access, you can specify this explicitly:
+
+```lua
+cmd = lspcontainers.command('mylsp', {
+  -- ...
+  network = "bridge",
+}),
+```
+
+If you find that an LSP that commonly requires network access doesn't have this
+by default, please open a PR updating its default (see `init.lua`).
+
 ## Process Id
 
 The LSP spec allows a client to sent its process id to a language server, so


### PR DESCRIPTION
Allow configuring individual LSPs to have no network access. By default,
LPSs will have no network access, but those that require it can have a
`network="bridge"` attribute (see `gopls` as an example).

This setting can also be overridden, so users with custom needs can
override the defaults, and it can also be specified for custom LSPs.