### PR TITLE
Parameter `extra_volumes` for mounting additional volumes on the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ require'lspconfig'.omnisharp.setup {
 }
 ```
 
+#### Mount Additional Volumes
+
+You can mount additional volumes to let the lsp server access caches or other directories.
+
+```lua
+require'lspconfig'.rust_analyzer.setup {
+  cmd = require'lspcontainers'.command(
+      'rust_analyzer',
+      {
+        extra_volumes = {
+          '/home/[UserName]/.cargo:/root/.cargo:ro',
+          ...
+        }
+      }
+  ),
+  ...
+}
+```
+
+The property `extra_volumes` recieves a list of strings formated for the `--volume` option of Docker.
+[See reference](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems).
+
 ### Podman Support
 
 If you are using podman instead of docker it is sufficient to just specify "podman" as `container_runtime`:


### PR DESCRIPTION
As proposed by @WhyNotHugo in the issue lspcontainers/dockerfiles#55, it could be useful to be able to mount additional directories to the containers. 

This could be a start on solving the "customization" on the go-lsp case, and support global caches, which is very common in several languages such as rust, C# (omnisharp/nuget), ruby (solargraph/bundle), etc.