### PR TITLE
fix(sysname): work with uname instead vim.fn.has

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -69,7 +69,7 @@ local supported_languages = {
 
 -- default command to run the lsp container
 local default_cmd = function (runtime, workdir, image, network, docker_volume)
-  if vim.fn.has("win32") then
+  if vim.loop.os_uname().sysname == "Windows_NT" then
     workdir = Dos2UnixSafePath(workdir)
   end
 


### PR DESCRIPTION
I use the appimage version of neovim and for some reason `vim.fn.has("win32")` returns true for me. So I did a little bit of searching and found [this suggestion](https://github.com/neovim/neovim/issues/13971#issuecomment-781883971) to check for the uname of the system neovim is running on. This fixes the issue for me.

Edit: `vim.fn.has("win32")` returning true is only a problem because I am on Fedora and it breaks the paths for my volumes of course