### PR TITLE
feat(server): Add tailwindcss language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Below is a list of supported language servers for configuration with `nvim-lspco
 - [solargraph](#solargraph)
 - [sumneko_lua](#sumneko_lua)
 - [svelte](#svelte)
+- [tailwindcss](#tailwindcss)
 - [terraformls](#terraformls)
 - [tsserver](#tsserver)
 - [vuels](#vuels)
@@ -439,6 +440,22 @@ require'lspconfig'.svelte.setup {
   end,
   cmd = require'lspcontainers'.command('svelte'),
   root_dir = util.root_pattern(".git", vim.fn.getcwd()),
+  ...
+}
+```
+
+### tailwindcss
+
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tailwindcss
+
+```lua
+require'lspconfig'.tailwindcss.setup {
+  before_init = function(params)
+  	params.processId = vim.NIL
+  end,
+  cmd = require'lspcontainers'.command('tailwindcss'),
+  filetypes = { "django-html", "htmldjango", "gohtml", "html", "markdown", "php", "css", "postcss", "sass", "scss", "stylus", "javascript", "javascriptreact", "rescript", "typescript", "typescriptreact", "vue", "svelte" },
+  root_dir = util.root_pattern("tailwind.config.js", "tailwind.config.ts", "postcss.config.js", "postcss.config.ts", "package.json", "node_modules", ".git", vim.fn.getcwd()),
   ...
 }
 ```

--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -56,6 +56,7 @@ local supported_languages = {
   solargraph = { image = "docker.io/lspcontainers/solargraph" },
   sumneko_lua = { image = "docker.io/lspcontainers/lua-language-server" },
   svelte = { image = "docker.io/lspcontainers/svelte-language-server" },
+  tailwindcss= { image = "docker.io/lspcontainers/tailwindcss-language-server" },
   terraformls = { image = "docker.io/lspcontainers/terraform-ls" },
   tsserver = { image = "docker.io/lspcontainers/typescript-language-server" },
   vuels = { image = "docker.io/lspcontainers/vue-language-server" },


### PR DESCRIPTION
This adds [tailwindcs language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/master/packages/tailwindcss-language-server). Should be merged only after lspcontainers/dockerfiles#75.