### PR TITLE
fix(api): add runtime parameter to images_remove

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -158,13 +158,14 @@ local function images_pull(runtime)
   print("lspcontainers: Language servers successfully pulled")
 end
 
-local function images_remove()
+local function images_remove(runtime)
   local jobs = {}
+  runtime = runtime or "docker"
 
   for _, v in pairs(supported_languages) do
     local job =
       vim.fn.jobstart(
-      "docker image rm --force "..v['image']..":latest",
+      runtime.." image rm --force "..v['image']..":latest",
       {
         on_stderr = on_event,
         on_stdout = on_event,


### PR DESCRIPTION
Without this parameter it is not possible to use the API with podman.

Fixes #75 