### PR TITLE
Add Nix flake support 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666424192,
+        "narHash": "sha256-rb/a7Kg9s31jqkvdOQHFrUc5ig5kB+O2ZKB8mjU2kW8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f8287f3d597c73b0d706cfad028c2d51821f64d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgs = forAllSystems (system:
+        import nixpkgs {
+          overlays = [ ];
+          inherit system;
+        });
+    in {
+      packages = forAllSystems (system: {
+        default = pkgs.${system}.vimUtils.buildVimPluginFrom2Nix {
+          name = "lspcontainers.nvim";
+          src = ./.;
+        };
+        neovim = pkgs.${system}.neovim.override {
+          configure = {
+            customRC = ''
+              lua << EOF
+                ${(builtins.readFile ./test/init.lua)};
+              EOF
+            '';
+            packages.main = with pkgs.${system}.vimPlugins; {
+              start = [
+                nvim-lspconfig
+                self.packages.${system}.default
+              ];
+            };
+          };
+        };
+      });
+
+      devShells = forAllSystems (system: {
+        default = pkgs.${system}.mkShellNoCC {
+          buildInputs = [ self.packages.${system}.neovim ];
+        };
+      });
+
+      apps = forAllSystems (system: {
+        neovim = {
+          program = "${self.packages.${system}.neovim}/bin/nvim";
+          type = "app";
+        };
+      });
+    };
+}

--- a/test/init.lua
+++ b/test/init.lua
@@ -1,0 +1,96 @@
+local function on_attach(client, bufnr)
+    local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+
+    local opts = { noremap = true, silent = true }
+
+    buf_set_keymap('n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
+    buf_set_keymap('n', 'gd', '<Cmd>lua vim.lsp.buf.definition()<CR>', opts)
+    buf_set_keymap('n', 'K', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
+    buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+    buf_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
+    buf_set_keymap('n', '<space>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
+    buf_set_keymap('n', '<space>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
+    buf_set_keymap('n', '<space>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
+    buf_set_keymap('n', '<space>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
+    buf_set_keymap('n', '<space>rn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+    buf_set_keymap('n', '<space>ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+    buf_set_keymap('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+    buf_set_keymap('n', '<space>e', '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>', opts)
+    buf_set_keymap('n', '[d', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts)
+    buf_set_keymap('n', ']d', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts)
+    buf_set_keymap('n', '<space>q', '<cmd>lua vim.lsp.diagnostic.set_loclist()<CR>', opts)
+
+    if client.server_capabilities.documentFormattingProvider then
+        buf_set_keymap("n", "<space>f", "<cmd>lua vim.lsp.buf.format({ async = true })<CR>", opts)
+    end
+
+    if client.server_capabilities.documentRangeFormattingProvider then
+        buf_set_keymap("v", "<space>f", "<cmd>lua vim.lsp.buf.range_formatting()<CR>", opts)
+    end
+
+    if client.server_capabilities.documentHighlightProvider then
+        vim.api.nvim_exec([[
+          augroup lsp_document_highlight
+            autocmd! * <buffer>
+            autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
+            autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
+          augroup END
+        ]], false)
+    end
+end
+
+local function make_config()
+    local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+    capabilities.textDocument.completion.completionItem.snippetSupport = true
+    capabilities.textDocument.completion.completionItem.resolveSupport = {
+        properties = {
+            'documentation',
+            'detail',
+            'additionalTextEdits',
+        }
+    }
+
+    return {
+        capabilities = capabilities,
+        on_attach = on_attach
+    }
+end
+
+local function setup_languages()
+    local lspcontainers_servers = {
+        "bashls",
+        "clangd",
+        "dockerls",
+        "gopls",
+        "graphql",
+        "html",
+        "intelephense",
+        "jsonls",
+        "omnisharp",
+        "powershell_es",
+        "prismals",
+        "pylsp",
+        "pyright",
+        "rust_analyzer",
+        "solargraph",
+        "sumneko_lua",
+        "svelte",
+        "tailwindcss",
+        "terraformls",
+        "tsserver",
+        "vuels",
+        "yamlls"
+    }
+
+    for _, server in pairs(lspcontainers_servers) do
+        local config = make_config()
+
+        config.cmd = require 'lspcontainers'.command(server)
+        config.root_dir = require 'lspconfig/util'.root_pattern(".git", vim.fn.getcwd())
+
+        require 'lspconfig'[server].setup(config)
+    end
+end
+
+setup_languages()


### PR DESCRIPTION
## Overview

Implements a `flake.nix` to allow for use with Nix for development and packaging. Includes a `devShell` with Neovim and pre-baked configuration with plugins.

## Changes

- adds `flake.nix` with outputs
- adds `test/init.lua` for devShell