### PR TITLE
fix(user-commands): not working due to unexpected arg

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -143,7 +143,7 @@ end
 
 local function images_pull(runtime)
   local jobs = {}
-  runtime = runtime or "docker"
+  if not (type(runtime) == "string") then runtime = "docker" end
 
   for idx, server_name in ipairs(Config.ensure_installed) do
     local server = supported_languages[server_name]
@@ -168,7 +168,7 @@ end
 
 local function images_remove(runtime)
   local jobs = {}
-  runtime = runtime or "docker"
+  if not (type(runtime) == "string") then runtime = "docker" end
 
   for _, v in pairs(supported_languages) do
     local job =


### PR DESCRIPTION
When a function is called by `nvim_create_user_command`, a single table argument is passed to that function. This resulted in all user commands not working due to trying to concatenate a string and a table.

The user commands are defined [here](https://github.com/lspcontainers/lspcontainers.nvim/blob/main/lua/lspcontainers/init.lua#L192-L193):
```lua
vim.api.nvim_create_user_command("LspImagesPull", images_pull, {})
vim.api.nvim_create_user_command("LspImagesRemove", images_remove, {})
```

`:help nvim_create_user_command`
![Screen Shot 2023-12-16 at 4 15 44 PM](https://github.com/lspcontainers/lspcontainers.nvim/assets/25430772/9aad133e-3c8f-4197-b0b9-71ad374e8ce6)
