### PR TITLE
feat: add `ts_ls` language server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Below is a list of supported language servers for configuration with `nvim-lspco
 - [svelte](#svelte)
 - [tailwindcss](#tailwindcss)
 - [terraformls](#terraformls)
+- [ts_ls](#ts_ls)
 - [tsserver](#tsserver)
 - [vuels](#vuels)
 - [yamlls](#yamlls)
@@ -496,6 +497,21 @@ https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.m
 require'lspconfig'.terraformls.setup {
   cmd = require'lspcontainers'.command('terraformls'),
   filetypes = { "hcl", "tf", "terraform", "tfvars" },
+  ...
+}
+```
+
+### ts_ls
+
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ts_ls
+
+```lua
+require'lspconfig'.ts_ls.setup {
+  before_init = function(params)
+    params.processId = vim.NIL
+  end,
+  cmd = require'lspcontainers'.command('ts_ls'),
+  root_dir = require'lspconfig/util'.root_pattern(".git", vim.fn.getcwd()),
   ...
 }
 ```

--- a/init.lua
+++ b/init.lua
@@ -80,6 +80,7 @@ local function setup_languages()
         "svelte",
         "tailwindcss",
         "terraformls",
+        "ts_ls",
         "tsserver",
         "vuels",
         "yamlls"

--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -65,6 +65,7 @@ local supported_languages = {
     svelte = { image = "docker.io/lspcontainers/svelte-language-server" },
     tailwindcss = { image = "docker.io/lspcontainers/tailwindcss-language-server" },
     terraformls = { image = "docker.io/lspcontainers/terraform-ls" },
+    ts_ls = { image = "docker.io/lspcontainers/typescript-language-server" },
     tsserver = { image = "docker.io/lspcontainers/typescript-language-server" },
     vuels = { image = "docker.io/lspcontainers/vue-language-server" },
     yamlls = { image = "docker.io/lspcontainers/yaml-language-server" },


### PR DESCRIPTION
nvim-lsp has updated the name of `tsserver` to `ts_ls` for disambiguation purposes. The underlying language server is still the same, so support should be as simple as adding it to the list of supported servers with the same image as `tsserver`. Lmk if I need to do anything else to get this across