### PR TITLE
Mount /tmp as tmpfs inside containers

### DIFF
--- a/lua/lspcontainers/init.lua
+++ b/lua/lspcontainers/init.lua
@@ -100,6 +100,7 @@ local default_cmd = function(runtime, workdir, image, network, docker_volume)
         "--network=" .. network,
         "--workdir=" .. workdir,
         mnt_volume,
+        "--tmpfs=/tmp",
         image
     }
 end


### PR DESCRIPTION
tsserver attempts to execute `realpath("/tmp")` at start-up, but fails because this directory is missing:

    [ERROR][2025-04-05 13:37:29] .../vim/lsp/rpc.lua:770	"rpc"	"/usr/bin/docker"	"stderr"	"node:internal/fs/promises:1169\n  return await PromisePrototypeThen(\n         ^\n\nError: ENOENT: no such file or directory, realpath '/tmp'\n    at async Object.realpath (node:internal/fs/promises:1169:10)\n    at async file:///usr/local/lib/node_modules/typescript-language-server/lib/cli.mjs:17916:30 {\n  errno: -2,\n  code: 'ENOENT',\n  syscall: 'realpath',\n  path: '/tmp'\n}\n\nNode.js v20.15.1\n"

Mount /tmp as tmpfs inside containers, so that they may all use a temporary directory in the usual fashion.